### PR TITLE
Add pixi-engine to the Engines section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Game Engines
 
 [hexi](https://github.com/kittykatattack/hexi) – minimalistic game engine with pixi rendering.
 
+[pixi-engine](https://github.com/gamestdio/pixi-engine) - Provides a minimal engine-like structure for developing games with PixiJS
 
 Integrations
 ============


### PR DESCRIPTION
I'm using [pixi-engine](https://github.com/gamestdio/pixi-engine) on http://crashracing.com/, and will continue supporting it for my future games.